### PR TITLE
Add deep clone to metaSteps

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const debug = require('debug')('codeceptjs:reportportal');
 const { isMainThread } = require('worker_threads');
 const worker = require('worker_threads');
+const deepClone = require('lodash.clonedeep')
 
 const {
   event, recorder, output, container,
@@ -413,7 +414,7 @@ module.exports = (config) => {
       debug(`${metaStep.tempId}: The stepId '${metaStep.toString()}' is started. Nested: ${isNested}`);
     }
 
-    currentMetaSteps = metaSteps;
+    currentMetaSteps = deepClone(metaSteps);
     return currentMetaSteps[currentMetaSteps.length - 1] || testObj;
   }
 

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   "homepage": "https://github.com:reportportal/agent-js-codecept#readme",
   "main": "index.js",
   "dependencies": {
-    "@reportportal/client-javascript": "^5.0.2"
+    "@reportportal/client-javascript": "^5.0.2",
+    "lodash": "^4.17.21"
   },
   "scripts": {
     "test": "mocha test/acceptance_test.js --timeout 6000"
   },
   "devDependencies": {
-    "codeceptjs": "2.5.0",    
+    "codeceptjs": "2.5.0",
     "chai": "^4.2.0",
     "eslint": "^6.6.0",
     "eslint-config-airbnb-base": "^14.0.0",


### PR DESCRIPTION
As codeceptjs works on the metaStep object in the background it happens
temporarily that the metaStep looses the success or failed status.
It has the status "queued" then. This leads to errors on the
reportportal server, which cannot handle the status "queued".

With the deepClone the metaStep in the reporter is uncoupled
from codeceptjs.

closes #11 